### PR TITLE
init fixes

### DIFF
--- a/src/reframework/autorun/hud_extensions/core.lua
+++ b/src/reframework/autorun/hud_extensions/core.lua
@@ -72,6 +72,7 @@ core.singletons = {
 
 function core.get_savedata()
 	local savedata_manager = core.singletons.savedata_manager
+	if not savedata_manager then return end
 	local savedata_idx = savedata_manager:get_field("CurrentUserDataIndex")
 	return savedata_manager:get_field("_UserSaveData"):get_field("_Data"):get_element(savedata_idx)
 end

--- a/src/reframework/autorun/hud_extensions/facility_updates.lua
+++ b/src/reframework/autorun/hud_extensions/facility_updates.lua
@@ -47,7 +47,7 @@ function facility_updates.get_shares_state()
 end
 
 function facility_updates.get_nest_state()
-	local rallus = facility_manager:get_field("<Rallus>k__BackingField")
+	local rallus = facility_manager and facility_manager:get_field("<Rallus>k__BackingField")
 	if not rallus then return end
 	
 	core.savedata.Nest.count = rallus:get_field("_SupplyNum")

--- a/src/reframework/autorun/hud_extensions/voucher_updates.lua
+++ b/src/reframework/autorun/hud_extensions/voucher_updates.lua
@@ -14,7 +14,7 @@ function voucher_updates.get_vouchers()
 end
 
 function voucher_updates.get_login_bonus()
-	local delivery = network_manager:get_field("_DeliveryService")
+	local delivery = network_manager and network_manager:get_field("_DeliveryService")
 	if not delivery then return end
 	core.savedata.vouchers.ready = delivery:call("isNeedPickupLoginBonus")
 	core.savedata.vouchers.days = delivery:call("getElapsedDays")


### PR DESCRIPTION
provide escapes for nil singletons on launch (possibly resulting from or resulting in launch getting stuck at black screen)